### PR TITLE
Deviconのiconの文字列を小文字にする処理を追加

### DIFF
--- a/app/components/Devicon/Devicon.tsx
+++ b/app/components/Devicon/Devicon.tsx
@@ -21,9 +21,10 @@ export const Devicon = ({
   className = "",
   ...props
 }: DeviconProps) => {
+  const lowerIcon = icon.toLocaleLowerCase();
   const Icon = (
     <i
-      className={`devicon-${abbreviation[icon] ?? icon}-plain ${className}`}
+      className={`devicon-${abbreviation[lowerIcon] ?? lowerIcon}-plain ${className}`}
       style={{ color, fontSize: size }}
       {...props}
     />

--- a/app/components/MemberCard/MemberCard.stories.ts
+++ b/app/components/MemberCard/MemberCard.stories.ts
@@ -19,7 +19,7 @@ export const LoggedIn: Story = {
     name: "Naoto Kido",
     role: "代表",
     description: "よわよわプログラマ",
-    stacks: ["kubernetes", "aws", "java", "go", "flutter"],
+    stacks: ["Kubernetes", "AWS", "Java", "Go", "Flutter"],
     headerImage: "https://pbs.twimg.com/profile_banners/1846395762277826560/1737992837/1500x500",
     iconImage: "https://avatars.githubusercontent.com/u/54303857",
     githubName: "naoido",


### PR DESCRIPTION
## 関連チケット
#33 

## 変更内容
- Deviconのiconの文字列を小文字にする処理を追加

## 動作確認
![image](https://github.com/user-attachments/assets/b8f47622-7c71-4a4c-83d1-ca1c3100f222)

## その他
- レビュワーへ伝えたい内容