### PR TITLE
Deviconで他のスタイルも適応できるよう修正

### DIFF
--- a/app/components/Devicon/Devicon.stories.ts
+++ b/app/components/Devicon/Devicon.stories.ts
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Icon: Story = {
   args: {
-    icon: 'storybook',
+    icon: "storybook",
     tooltip: 'disable',
     size: '100px'
   },
@@ -27,7 +27,24 @@ export const Icon: Story = {
 
 export const IconWithTooltip: Story = {
   args: {
-    icon: 'storybook',
+    icon: "storybook",
+    tooltip: 'enable',
+    size: '100px'
+  },
+};
+
+export const IconWhenSpecialClassPattern: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "`icon`に技術名がそのまま使用できない場合、`devicon-`以降のクラス名を入力することで反映されます。(`go-original-wordmark`)\n\n"
+        + "もしくは、クラス名をそのまま入力することでも反映されます。(`devicon-go-original-wordmark`)\n\n"
+        + "技術名に大文字を入れた場合は、Tooltipの文字列に大文字が反映されます。"
+      }
+    }
+  },
+  args: {
+    icon: "Go-wordmark",
     tooltip: 'enable',
     size: '100px'
   },

--- a/app/components/Devicon/Devicon.tsx
+++ b/app/components/Devicon/Devicon.tsx
@@ -6,11 +6,26 @@ export interface DeviconProps {
   tooltip?: 'enable' | 'disable';
   color?: string;
   size?: string;
-  className?: string;
 }
 
 const abbreviation: Record<string, string> = {
   "aws": "amazonwebservices",
+}
+
+const parseIconClass = (icon: string): Record<'name' | 'iconClass', string> => {
+  const parts = icon.replace(/^devicon-/, '').split("-");
+
+  const name = parts[0];
+  const lowerName = name.toLocaleLowerCase();
+
+  const rest = parts.slice(1);
+  const style = `-${rest.find(part => ['plain', 'original'].includes(part)) ?? 'plain'}`;
+  const suffix = rest.includes('wordmark') ? '-wordmark' : '';
+
+  return {
+    name: name,
+    iconClass: `devicon-${abbreviation[lowerName] ?? lowerName}${style}${suffix}`
+  };
 }
 
 export const Devicon = ({
@@ -18,13 +33,12 @@ export const Devicon = ({
   tooltip = 'enable',
   color = "var(--based-color)",
   size = "20px",
-  className = "",
   ...props
 }: DeviconProps) => {
-  const lowerIcon = icon.toLocaleLowerCase();
+  const {name, iconClass} = parseIconClass(icon);
   const Icon = (
     <i
-      className={`devicon-${abbreviation[lowerIcon] ?? lowerIcon}-plain ${className}`}
+      className={iconClass}
       style={{ color, fontSize: size }}
       {...props}
     />
@@ -33,7 +47,7 @@ export const Devicon = ({
   return (
     (tooltip === 'disable') ?
     Icon :
-    <Tooltip content={icon}>
+    <Tooltip content={name}>
       {Icon}
     </Tooltip>
   );

--- a/app/components/MemberCard/MemberCard.stories.ts
+++ b/app/components/MemberCard/MemberCard.stories.ts
@@ -14,12 +14,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const LoggedIn: Story = {
+export const Default: Story = {
   args: {
     name: "Naoto Kido",
     role: "代表",
     description: "よわよわプログラマ",
-    stacks: ["Kubernetes", "AWS", "Java", "Go", "Flutter"],
+    stacks: ["Kubernetes", "AWS", "Java", "Go-wordmark", "Flutter"],
     headerImage: "https://pbs.twimg.com/profile_banners/1846395762277826560/1737992837/1500x500",
     iconImage: "https://avatars.githubusercontent.com/u/54303857",
     githubName: "naoido",


### PR DESCRIPTION
## 関連チケット
#39 

## 変更内容
deviconのicon指定を様々なスタイルを指定できるように修正
例: `devicon-go-original-wordmark`, `go-original-wordmark`, `Go-original-wordmark`, `Go-wordmark`
これらは同じようにGoの文字アイコンが適応されます。

## 動作確認
以下は`Go-original-wordmark`で指定した時のスクリーンショットです。
![image](https://github.com/user-attachments/assets/8932d9e7-cf53-479a-adc5-9080a97ae840)


## その他